### PR TITLE
fix: use absolute URLs for assets

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -4,13 +4,13 @@
       <div class="accenture-brand__item col-start-11 col-end-13
                           col-start-9-s col-end-11-s
                           col-start-5-xs col-end-12-xs">
-        <img alt="Accenture Interactive" class="accenture-brand__logo" src="./assets/accenture-logo.svg">
+        <img alt="Accenture Interactive" class="accenture-brand__logo" src="/assets/accenture-logo.svg">
       </div>
     </div>
   </div>
   <div class="grid footer__wrapper">
     <a class="footer__s2-link col-start-1 col-end-6" href="/">
-      <img alt="Sinnerschrader" src="./assets/sinnerschrader-logo.svg"/>
+      <img alt="SinnerSchrader" src="/assets/sinnerschrader-logo.svg"/>
     </a>
     <span class="footer__s2-conference-links col-start-1 col-end-12">
       Creator of <a class="footer__link underline-white" href="https://nextconf.eu/" rel="external nofollow">NEXT Conference</a>

--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -1,19 +1,18 @@
 <head>
-  <link rel="stylesheet" type="text/css" href="{{ './index.css' | url }}"/>
-  <link rel="preload" href="./assets/fonts/Ogg-RegularItalic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="./assets/fonts/Ogg-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="./assets/fonts/RobotoMono-Regular.ttf" as="font" type="font/ttf" crossorigin>
-  <link rel="preload" href="./assets/fonts/SuisseIntl-Regular-WebM.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="./assets/fonts/SuisseIntl-SemiBold-WebM.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="./assets/fonts/SuisseIntl-Light-WebM.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" type="text/css" href="/index.css"/>
+  <link rel="preload" href="/assets/fonts/Ogg-RegularItalic.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/Ogg-Regular.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/RobotoMono-Regular.ttf" as="font" type="font/ttf" crossorigin>
+  <link rel="preload" href="/assets/fonts/SuisseIntl-Regular-WebM.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/SuisseIntl-SemiBold-WebM.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/SuisseIntl-Light-WebM.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preconnect" href="https://sinnerschrader.jobs" crossorigin/>
-  <link rel="preconnect" href="https://sinnerschrader.news" crossorigin />
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <meta charset="utf-8"/>
 
-  <link rel="mask-icon" href="./assets/favicon.svg">
-  <link rel="alternate icon" type="image/png" href="./assets/favicon.png">
-  <link rel="icon" type="image/svg+xml" href="./assets/favicon.svg">
+  <link rel="mask-icon" href="/assets/favicon.svg">
+  <link rel="alternate icon" type="image/png" href="/assets/favicon.png">
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
 
   <!-- Primary Meta Tags -->
   <title>SinnerSchrader | Experience Design and Engineering Agency.</title>


### PR DESCRIPTION
this ensures our error page looks to the correct locations of the fonts, images and CSS all the times