### PR TITLE
fix(offering): unset swiper default style to show overlap on mobile

### DIFF
--- a/_includes/js/offerings.js
+++ b/_includes/js/offerings.js
@@ -9,6 +9,7 @@ class Offerings {
 			breakpoints: {
 				300: {
 					slidesPerView: "auto",
+					spaceBetween: 48,
 					grabCursor: true,
 				},
 				450: {

--- a/_includes/offering.liquid
+++ b/_includes/offering.liquid
@@ -46,7 +46,7 @@
 	  <div class="offering--info grid">
 		  <div class="swiper-wrapper">
 			  {% for offering in data.offerings.offeringList %}
-			  <div class="swiper-slide">
+			  <div class="swiper-slide offering__slide">
 				  <h4 class="offering__title">{{ offering.title }}</h4>
 				  <ul class="offering__list">
 					  {% for item in offering.list %}

--- a/styles/includes/_offering.scss
+++ b/styles/includes/_offering.scss
@@ -74,6 +74,10 @@
 
 		position: relative;
 		z-index: 4;
+
+		.offering__slide {
+			width: auto;
+		}
 	}
 
 	&__title {


### PR DESCRIPTION
The auto mode sets the width to 100% - but we want an overlapping effect.
Therefore we need to overwrite the built-in swiper styles and set the width back to auto

In addition, it also increases the space between the different sections on mobile like it's in the design